### PR TITLE
Feat/postgres integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ build/
 .idea/
 *.iml
 out/
+
+# Ignore VS Code configuration files
+.vscode/
+client/bin/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Run Commands
+
+This is a multi-module Gradle project (Kotlin DSL) targeting **Java 24**. Use the included Gradle wrapper.
+
+```bash
+# Build everything
+gradlew.bat build
+
+# Run client (Swing GUI chess game)
+gradlew.bat :client:run
+
+# Run server (Spring Boot REST API)
+gradlew.bat :server:bootRun
+
+# Run all tests
+gradlew.bat test
+
+# Run tests for a single module
+gradlew.bat :client:test
+gradlew.bat :server:test
+
+# Run a single test class
+gradlew.bat :server:test --tests "com.chessoop.server.SomeTestClass"
+
+# Clean build
+gradlew.bat clean build
+```
+
+## Architecture
+
+Two independent modules sharing no code:
+
+### `client/` — Swing Chess GUI
+- **Entry point:** `Game.GameRun` — creates JFrame with Board panel
+- **Game logic:** `Game.Board` — manages 8x8 grid, piece list, turn tracking, move validation, captures, and pawn promotion
+- **Input:** `Game.Input` (MouseAdapter) — click-drag-release to move pieces
+- **Piece hierarchy:** Abstract `Piece.Piece` base class with subclasses `King`, `Queen`, `Rook`, `Bishop`, `Knight`, `Pawn` — each implements `isValidMove(toCol, toRow, Board)` with piece-specific movement rules
+- Rendering via `Graphics2D` and `BufferedImage` sprites
+
+### `server/` — Spring Boot REST API
+- **Entry point:** `com.chessoop.server.ServerApplication`
+- **Layers:** Controller → Service → Repository (standard Spring architecture)
+- **API endpoints** (`/api/v1`):
+  - `POST /results` — record a game result (upserts players, applies Elo, persists GameResult)
+  - `GET /leaderboard?limit=N` — top players sorted by Elo then wins
+  - `GET /ping`, `POST /echo` — debug endpoints
+- **Entities:** `Player` (UUID, name, elo, wins, losses) and `GameResult` (white/black Player refs, winner enum, PGN, timestamp)
+- **DTOs** are Java `record` classes in `api/dto/`
+- **Elo system:** K-factor=32, standard chess Elo formula in `ResultService`
+
+### Database Profiles
+- **H2 (default/dev):** `application-h2.properties` — in-memory `jdbc:h2:mem:chess`, console at `/h2-console`
+- **Postgres (prod):** `application-postgres.properties` — reads connection from env vars (`SPRING_DATASOURCE_URL`, etc.)
+- **Docker:** `docker-compose.yml` provides a Postgres 16 container (db: `chessdb`, user: `chess`, pass: `secret`)
+
+## Conventions
+- Client uses uppercase package names (`Game/`, `Piece/`) — match this when adding client code
+- Server follows standard Spring Boot package conventions under `com.chessoop.server`
+- JUnit 5 for all tests
+- Git branches use prefixes: `feat/`, `fix/`, `chore/`, `ci/`

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Originally built as a collaborative class project, I (Ian Lingo) have since take
 - Implementing a Spring Boot backend for leaderboards and results.
 - Designing REST APIs and integrating Elo rating updates.
 - Adding PostgreSQL support with Docker Compose for persistent storage.
+- Integrating the Swing client with the Spring Boot server to automatically POST game results upon completion of game.
 
 ## Modules
 
@@ -39,8 +40,8 @@ game interface. <br>
 - Enforces turn order (White and Black alternate each move).
 - Implements Pawn Promotion: a pawn that reaches the opponent's back rank is
   automatically promoted to a Queen.
-- A player wins by capturing the opposing King, after which the
-  program closes automatically.
+- A player wins by capturing the opposing King; a win dialog is displayed and the result is automatically sent to the server.
+- Prompts both players for their names before the game starts.
 - Visual board and sprite rendering is done via Java's `Graphics2D` and `BufferedImage`.
 
 ### Server (Spring Boot)
@@ -52,6 +53,7 @@ game interface. <br>
 - Elo reating system with wins/losses tracked.
 - In-memory H2 database for development console available at: [http//localhost:8080/h2-console](http//localhost:8080/h2-console)
 - PostgreSQL for production via Docker Compose (`docker compose up -d`)
+- Game results are automatically received from the Swing client upon game completion. 
 
 ## How to Run
 

--- a/README.md
+++ b/README.md
@@ -8,50 +8,59 @@ This project showcases our understanding of <strong>Object-Oriented Programming 
 functional chess game using Java with a <strong>Swing-based GUI</strong>. <br>
 
 ## Development Notes
+
 Originally built as a collaborative class project, I (Ian Lingo) have since taken the lead on expanding the application far beyond the original requirements. My additions include:
+
 - Creating JavaDocs documentation.
 - Adding additional GUI features such as player turn indicator and side bar.
 - Migrating the project to a multi-module Gradle build (client + server).
 - Adding unit testing (JUnit 5).
-- Implementing a Spring Boot backend with H2 for leaderboards and results.
+- Implementing a Spring Boot backend for leaderboards and results.
 - Designing REST APIs and integrating Elo rating updates.
+- Adding PostgreSQL support with Docker Compose for persistent storage.
 
 ## Modules
+
 - client/ <br>
-    * `Game`: Handles the game board, movement validation, input handling, and UI rendering. <br>
-    * `Piece`: Contains all chess piece classes (`Pawn`, `Rook`, `Bishop`, etc.) with piece-specific logic.
+  - `Game`: Handles the game board, movement validation, input handling, and UI rendering. <br>
+  - `Piece`: Contains all chess piece classes (`Pawn`, `Rook`, `Bishop`, etc.) with piece-specific logic.
 
 - server/ <br>
-    * Spring Boot REST API with H2 database. Stores player profiles, Elo ratings, and game results.
+  - Spring Boot REST API with H2 (dev) and PostgreSQL (prod) database profiles. Stores player profiles, Elo ratings, and game results.
 
-The entry point is the `GameRun.java` file within the `Game`  package, which initializes and launches the chess 
+The entry point is the `GameRun.java` file within the `Game` package, which initializes and launches the chess
 game interface. <br>
 
 ## Features
 
 ### Client (Swing)
-* Click and drag pieces using your mouse.
-* Enforces turn order (White and Black alternate each move).
-* Implements Pawn Promotion: a pawn that reaches the opponent's back rank is 
-    automatically promoted to a Queen.
-* A player wins by capturing the opposing King, after which the 
-    program closes automatically.
-* Visual board and sprite rendering is done via Java's `Graphics2D` and `BufferedImage`.
+
+- Click and drag pieces using your mouse.
+- Enforces turn order (White and Black alternate each move).
+- Implements Pawn Promotion: a pawn that reaches the opponent's back rank is
+  automatically promoted to a Queen.
+- A player wins by capturing the opposing King, after which the
+  program closes automatically.
+- Visual board and sprite rendering is done via Java's `Graphics2D` and `BufferedImage`.
 
 ### Server (Spring Boot)
-* REST endpoints:
-    * `POST /api/v1/results` -> record game results
-    * `GET /api/v1/leaderboard?limit=N` -> fetch top N players
-* Player "profiles" are automatically created or updated by name.
-* Elo reating system with wins/losses tracked.
-* In-memory H2 database (no setup required). Console available at: [http//localhost:8080/h2-console](http//localhost:8080/h2-console)
+
+- REST endpoints:
+  - `POST /api/v1/results` -> record game results
+  - `GET /api/v1/leaderboard?limit=N` -> fetch top N players
+- Player "profiles" are automatically created or updated by name.
+- Elo reating system with wins/losses tracked.
+- In-memory H2 database for development console available at: [http//localhost:8080/h2-console](http//localhost:8080/h2-console)
+- PostgreSQL for production via Docker Compose (`docker compose up -d`)
 
 ## How to Run
 
 ### Prerequisites
-* Java 24
-* Gradle wrapper (included)
-  
+
+- Java 24
+- Gradle wrapper (included)
+- Docker (for PostgreSQL database)
+
 <ol>
     <li> Clone or download all source files from this GitHub repository.</li>
     <li> Ensure you have <strong>Java 24 or later</strong> installed</li>
@@ -59,6 +68,7 @@ game interface. <br>
 </ol>
 
 #### Run Client (GUI Chess):
+
 <pre># On macOS/Linux
 ./gradlew :client:run
 
@@ -66,18 +76,22 @@ game interface. <br>
 gradlew.bat :client:run </pre>
 
 #### Run Server (REST API):
+
 <pre># On macOS/Linux
 ./gradlew :client:bootRun
 
 # On Windows
 gradlew.bat :client:bootRun </pre>
+
 Once running:
-* Visit H2 console -> `http://localhost:8080/h2-console`
-    * JDBC URL: `jdbc:h2:mem:chess`
-    * User: `sa`
-    * Password: *(blank)*
+
+- Visit H2 console -> `http://localhost:8080/h2-console`
+  - JDBC URL: `jdbc:h2:mem:chess`
+  - User: `sa`
+  - Password: _(blank)_
 
 ### Test API (optional)
+
 <pre># record a result (White beats Black)
 curl -X POST http://localhost:8080/api/v1/results \
   -H "Content-Type: application/json" \
@@ -86,6 +100,17 @@ curl -X POST http://localhost:8080/api/v1/results \
 # fetch leaderboard
 curl "http://localhost:8080/api/v1/leaderboard?limit=10" </pre>
 
+#### Run Server with PostgreSQL:
+
+<pre># Start Postgres container
+docker compose up -d
+
+# On macOS/Linux
+SPRING_PROFILES_ACTIVE=postgres ./gradlew :server:bootRun
+
+# On Windows
+set SPRING_PROFILES_ACTIVE=postgres
+gradlew.bat :server:bootRun </pre>
 
 ## Project Significance
 
@@ -93,12 +118,13 @@ curl "http://localhost:8080/api/v1/leaderboard?limit=10" </pre>
     <li> Demonstrates <strong>Object-Oriented Principles and Design</strong> (abstraction, polymorphism, inheritance, encapsulation</li>
     <li> GUI development using <strong>Java Swing</strong></li>
     <li> Practical use of <strong>Gradle (Kotlin DSL)</strong> multi-module builds.</li>
-    <li> Backend experience with <strong>Spring Boot, REST APIs, and H2 database</strong>.</li>
+    <li> Backend experience with <strong>Spring Boot, REST APIs, H2, and PostgreSQL</strong>.</li>
     <li> Implements an <strong>Elo</strong> rating system to persist player performance.</li>
     <li> Collaboration with <strong>Git</strong>, version control, and clean architecture.</li>
 </ul>
 
 ## Documentation
+
 View Full JavaDocs Online: [Click here to open the JavaDocs](https://ian8912.github.io/ChessOOP/)
 
 Thank you for checking out this project!

--- a/client/src/main/java/Game/Board.java
+++ b/client/src/main/java/Game/Board.java
@@ -39,6 +39,10 @@ public class Board extends JPanel {
     /** The JTextArea component used to display information associated with the board.*/
     private JTextArea infoArea;
 
+    /** Names of the two players, set before the game starts. */
+    private String whiteName = "White";
+    private String blackName = "Black";
+
     /** Handles mouse input events and piece interaction. */
     public Input in = new Input(this);
 
@@ -118,6 +122,17 @@ public class Board extends JPanel {
     public void setInfoArea(JTextArea infoArea){
 
         this.infoArea = infoArea;
+    }
+
+    /**
+     * Sets the display names for both players.
+     *
+     * @param whiteName name of the white player
+     * @param blackName name of the black player
+     */
+    public void setPlayerNames(String whiteName, String blackName) {
+        this.whiteName = whiteName;
+        this.blackName = blackName;
     }
 
     /**
@@ -262,13 +277,18 @@ public class Board extends JPanel {
         }
 
         if(move.Capture instanceof King){
-            System.out.println();
+            String winner;
+            String message;
             if(move.piece.getColor() == PieceColor.WHITE){
-                System.out.println("White team wins!\n");
+                winner = "WHITE";
+                message = whiteName + " (White) wins!";
             }
             else{
-                System.out.println("Black team wins!\n");
+                winner = "BLACK";
+                message = blackName + " (Black) wins!";
             }
+            ServerClient.postResult(whiteName, blackName, winner);
+            JOptionPane.showMessageDialog(this, message, "Game Over", JOptionPane.INFORMATION_MESSAGE);
             System.exit(0);
         }
     }

--- a/client/src/main/java/Game/GameRun.java
+++ b/client/src/main/java/Game/GameRun.java
@@ -21,12 +21,19 @@ public class GameRun {
 
         System.out.println("GameRun launched");
 
+        String whiteName = JOptionPane.showInputDialog(null, "Enter White player's name:", "Player Setup", JOptionPane.PLAIN_MESSAGE);
+        if (whiteName == null || whiteName.isBlank()) whiteName = "White";
+
+        String blackName = JOptionPane.showInputDialog(null, "Enter Black player's name:", "Player Setup", JOptionPane.PLAIN_MESSAGE);
+        if (blackName == null || blackName.isBlank()) blackName = "Black";
+
         JFrame frame = new JFrame("Chess");
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         frame.setLayout(new BorderLayout());
-        
+
         Board board = new Board();
         board.addPieces();
+        board.setPlayerNames(whiteName, blackName);
 
         JTextArea infoArea = new JTextArea(5, 23);
         infoArea.setEditable(false);

--- a/client/src/main/java/Game/ServerClient.java
+++ b/client/src/main/java/Game/ServerClient.java
@@ -1,0 +1,43 @@
+package Game;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+/**
+ * Sends game results to the Chess REST API server.
+ */
+public class ServerClient {
+
+    private static final String SERVER_URL = "http://localhost:8080/api/v1/results";
+
+    /**
+     * Posts a game result to the server in the background.
+     * Failures are silently ignored so the client never crashes if the server is offline.
+     *
+     * @param whiteName name of the white player
+     * @param blackName name of the black player
+     * @param winner    "WHITE" or "BLACK"
+     */
+    public static void postResult(String whiteName, String blackName, String winner) {
+        String json = String.format(
+            "{\"whiteName\":\"%s\",\"blackName\":\"%s\",\"winner\":\"%s\"}",
+            whiteName, blackName, winner
+        );
+
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create(SERVER_URL))
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(json))
+            .build();
+
+        client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+            .thenAccept(response -> System.out.println("Server response: " + response.statusCode()))
+            .exceptionally(ex -> {
+                System.err.println("Could not reach server: " + ex.getMessage());
+                return null;
+            });
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  db:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: chessdb
+      POSTGRES_USER: chess
+      POSTGRES_PASSWORD: secret
+    ports:
+      - "5432:5432"   # if 5432 is busy, change to "5433:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+volumes:
+  pgdata:

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -22,7 +22,8 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
-	runtimeOnly("com.h2database:h2")
+	runtimeOnly("com.h2database:h2")				// development test
+	runtimeOnly("org.postgresql:postgresql")        // prod
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/server/src/main/resources/application-h2.properties
+++ b/server/src/main/resources/application-h2.properties
@@ -1,0 +1,8 @@
+# --- H2 & JPA for dev ---
+spring.h2.console.enabled=true
+
+# In-memory DB (fresh each run). H2 console at /h2-console
+spring.datasource.url=jdbc:h2:mem:chess;DB_CLOSE_DELAY=-1
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=update

--- a/server/src/main/resources/application-postgres.properties
+++ b/server/src/main/resources/application-postgres.properties
@@ -1,0 +1,4 @@
+spring.datasource.url=${SPRING_DATASOURCE_URL}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
+spring.datasource.driver-class-name=org.postgresql.Driver

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -3,12 +3,10 @@ spring.application.name=server
 # --- H2 & JPA for dev ---
 spring.h2.console.enabled=true
 
-# In-memory DB (fresh each run). H2 console at /h2-console
-spring.datasource.url=jdbc:h2:mem:chess;DB_CLOSE_DELAY=-1
-spring.datasource.username=sa
-spring.datasource.password=
+# Common JPA/diagnostics (apply to all profiles)
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.jdbc.time_zone=UTC
 
+# Error text in dev/PRs
 server.error.include-message=always
 server.error.include-binding-errors=always


### PR DESCRIPTION
- Added PostgreSQL support via Docker Compose with a Spring profile for environment-specific database switching (h2 for dev, postgres for prod)
- Wired the Swing client to the Spring Boot server — prompts players for names at startup and automatically POSTs game results upon game completion
- Added ServerClient.java using Java's built-in HttpClient; server failures are handled gracefully so the client never crashes if the server is offline
- Updated README to document Postgres setup, new run instructions, and client-server integration
- Added CLAUDE.md for Claude Code context